### PR TITLE
Add banned network enforcement and ISP tracking

### DIFF
--- a/addnewuser.php
+++ b/addnewuser.php
@@ -1,83 +1,187 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+
+ensureSessionStarted();
+$csrfToken = getCsrfToken();
+$config = require __DIR__ . '/includes/config.php';
+?>
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-<meta charset="UTF-8">
-<title>Create a New Account</title>
-<meta name = "viewport" content = "width = device-width">
-<meta name = "viewport" content = "initial-scale = 1.0">
-<script type="text/javascript" language="JavaScript">
-<!--
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Create a New Account | <?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?></title>
+    <link rel="stylesheet" href="stylesheet.css">
+    <style>
+        body {
+            background-image: url("/images/vaderdeathstar.jpg");
+            background-color: black;
+            background-repeat: no-repeat;
+            background-attachment: fixed;
+            background-position: center;
+            background-size: cover;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            color: #f8f9fa;
+        }
 
-function BothFieldsIdenticalCaseSensitive() {
-var one = document.NewUser.realpassword.value;
-var another = document.NewUser.confirmpassword.value;
-if(one == another) { return true; }
-alert("Password fields must be the same.");
-return false;
-}
-//-->
-</script>
-<style>
-body  {
-    background-image: url("/images/vaderdeathstar.jpg");
-    background-color: black;
-    background-repeat: no-repeat;
-    background-attachment: fixed; 
-    background-position: center;
-    background-size: cover;
-}
-a:link {
-    color: green;
-    background-color: transparent;
-    text-decoration: none;
-}
-a:visited {
-    color: orange;
-    background-color: transparent;
-    text-decoration: none;
-}
-a:hover {
-    color: red;
-    background-color: transparent;
-    text-decoration: underline;
-}
-a:active {
-    color: yellow;
-    background-color: transparent;
-    text-decoration: underline;
-}
-</style>
+        .register-wrapper {
+            max-width: 540px;
+            margin: 4rem auto;
+            background: rgba(12, 12, 16, 0.85);
+            border-radius: 16px;
+            padding: 2.5rem;
+            box-shadow: 0 25px 45px rgba(0, 0, 0, 0.65);
+            backdrop-filter: blur(6px);
+        }
 
+        .register-wrapper h1 {
+            font-size: 2rem;
+            margin-bottom: 0.25rem;
+            text-align: center;
+            letter-spacing: 0.08em;
+        }
+
+        .register-wrapper p.subtitle {
+            text-align: center;
+            margin-bottom: 2rem;
+            color: #e0e6ed;
+            font-size: 0.95rem;
+        }
+
+        .form-group {
+            margin-bottom: 1.5rem;
+        }
+
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 0.35rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            color: #9fb3c8;
+        }
+
+        input[type="text"],
+        input[type="email"],
+        input[type="password"] {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border-radius: 8px;
+            border: 1px solid rgba(159, 179, 200, 0.25);
+            background: rgba(10, 12, 18, 0.9);
+            color: #ffffff;
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        input[type="text"]:focus,
+        input[type="email"]:focus,
+        input[type="password"]:focus {
+            border-color: #5bc0de;
+            box-shadow: 0 0 0 3px rgba(91, 192, 222, 0.25);
+            outline: none;
+        }
+
+        .form-actions {
+            text-align: center;
+            margin-top: 2rem;
+        }
+
+        button[type="submit"] {
+            background: linear-gradient(135deg, #28a745, #20c997);
+            color: #ffffff;
+            border: none;
+            padding: 0.85rem 2.5rem;
+            font-size: 1.05rem;
+            border-radius: 999px;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button[type="submit"]:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 15px 30px rgba(32, 201, 151, 0.35);
+        }
+
+        .requirements {
+            font-size: 0.85rem;
+            line-height: 1.5;
+            color: #cbd5e1;
+            margin-top: 0.5rem;
+        }
+
+        .terms {
+            font-size: 0.85rem;
+            color: #a0aec0;
+        }
+
+        a {
+            color: #5bc0de;
+        }
+
+        a:hover {
+            color: #63e6be;
+            text-decoration: underline;
+        }
+
+        .nav-link {
+            text-align: center;
+            margin-top: 1rem;
+        }
+
+        .nav-link a {
+            font-weight: 600;
+            letter-spacing: 0.08em;
+        }
+    </style>
 </head>
 <body>
-<body style="font-family: arial; font-style: gill-sans">
-<p><center><b><a href="/index.php">Home</a></b></p>
-<table>
-<form name="NewUser" action="newuserpost.php" method="post" border="0">
-<p><b><u><center><Font Color="white">REGISTER AN ACCOUNT</Font></p></center></b></u>
-<tr>
-	<td><Font Color="#FFFFFF"><b>Account Name</b></Font></td>
-	<td><input type="text" name="useraccountname"/></td>
-</tr><tr>
-	<td><Font Color="#FFFFFF"><b>Password</b></Font></td>
-    <td><input type="password" name="realpassword"/></td>
-</tr><tr>
-	<td><Font Color="#FFFFFF"><b>Confirm Password</b></Font></td>
-    <td><input type="password" name="confirmpassword"/></td>
-</tr><tr>
-	<td><Font Color="#FFFFFF"><b>Access Level</b></Font></td>
-    <td><select name="accesslevel">
-	    <option value="standard">Standard</option>
-    </select></td>
-</tr>
-<tr><td></td><td>
-	<input type="hidden" name="action" value="create"/>
-	<input type="submit" onclick="return BothFieldsIdenticalCaseSensitive();" value="Submit"/>
-</td></tr>
-</center>
-</form>
-</table>
-<br />
-<center><a href="#" download><font size="+2"><b><u>>>Download Client<<</u></b></font></a></center>
+    <div class="register-wrapper" role="form">
+        <h1>Join the Fight</h1>
+        <p class="subtitle">Secure your SWG Source account and prepare for battle.</p>
+        <form name="NewUser" action="newuserpost.php" method="post" novalidate>
+            <div class="form-group">
+                <label for="useraccountname">Account Name</label>
+                <input type="text" id="useraccountname" name="useraccountname" required pattern="^[A-Za-z0-9_\-]{4,32}$" maxlength="32" autocomplete="username">
+                <div class="requirements">Use 4-32 characters. Letters, numbers, hyphen and underscore only.</div>
+            </div>
+            <div class="form-group">
+                <label for="email">Email Address</label>
+                <input type="email" id="email" name="email" required maxlength="190" autocomplete="email">
+                <div class="requirements">We will send a verification link to confirm your identity.</div>
+            </div>
+            <div class="form-group">
+                <label for="realpassword">Password</label>
+                <input type="password" id="realpassword" name="realpassword" required autocomplete="new-password" minlength="12">
+                <div class="requirements">Minimum 12 characters including uppercase, lowercase, number and symbol.</div>
+            </div>
+            <div class="form-group">
+                <label for="confirmpassword">Confirm Password</label>
+                <input type="password" id="confirmpassword" name="confirmpassword" required autocomplete="new-password">
+            </div>
+            <div class="form-group terms">
+                <label>
+                    <input type="checkbox" name="terms" value="yes" required> I agree to follow the community code of conduct and accept the privacy policy.
+                </label>
+            </div>
+            <input type="hidden" name="action" value="create">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+            <div class="form-actions">
+                <button type="submit">Create My Account</button>
+            </div>
+        </form>
+        <div class="nav-link">
+            <a href="/form_login.php">Already have an account? Sign in.</a>
+        </div>
+        <div class="nav-link">
+            <a href="/index.php">Return to Command Center</a>
+        </div>
+    </div>
 </body>
 </html>

--- a/auth.php
+++ b/auth.php
@@ -1,83 +1,85 @@
 <?php
-header('Content-Type: text/html; charset=utf-8');
+declare(strict_types=1);
 
-// #######################################################################
-// ####################### SET PHP ENVIRONMENT ###########################
-// #######################################################################
+header('Content-Type: application/json; charset=utf-8');
 
-#ini_set('display_errors', 1);
-date_default_timezone_set('America/Chicago');
+date_default_timezone_set('UTC');
 
-include 'includes/db_connect.php';
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
 
-// #######################################################################
-// ########################### FUNCTIONS #################################
-// #######################################################################
+$config = require __DIR__ . '/includes/config.php';
 
-function getUserByEmailAndPassword($username, $password) {
-	global $mysqli;
-	$result = $mysqli->query("SELECT * FROM user_account WHERE username = '$username'") or die(mysql_error());
-	$no_of_rows = $result->num_rows;
-	if ($no_of_rows > 0) {
-		$result = $result->fetch_array();
-		$salt = $result['password_salt'];
-		$stored_hash = $result['password_hash'];
-		$hashtest = checkhashSSHA($salt, $password);
-		if ($hashtest == $stored_hash) {
-			return $result;
-		}
-	}
-	else {
-		return false;
-	}
+$ipAddress = currentIpAddress();
+$banRecord = findBannedNetwork($mysqli, $ipAddress);
+
+if ($banRecord) {
+    logSecurityEvent($mysqli, 'ip_blocked', $ipAddress);
+    $banReason = $banRecord['reason'] ?? '';
+    $message = 'Access from this network has been blocked by ' . $config['site_name'] . ' security.';
+
+    if ($banReason !== '') {
+        $message .= ' Reason: ' . $banReason . '.';
+    }
+
+    echo json_encode(['message' => $message]);
+    exit;
 }
 
-function checkhashSSHA($salt, $password) {
-	$hash = base64_encode(sha1($password . $salt, true) . $salt);
-	return $hash;
+purgeOldSecurityEvents($mysqli);
+
+$maxAttempts = max(1, $config['login']['max_attempts'] ?? 10);
+$intervalSeconds = max(60, $config['login']['interval_seconds'] ?? 900);
+
+if (hasExceededRateLimit($mysqli, 'api_auth', $ipAddress, $maxAttempts, $intervalSeconds)) {
+    echo json_encode(['message' => 'Too many authentication attempts. Please slow down.']);
+    exit;
 }
 
-// #######################################################################
-// ######################### POST GET ITEMS ##############################
-// #######################################################################
+$username = trim((string) ($_POST['user_name'] ?? ''));
+$password = (string) ($_POST['user_password'] ?? '');
+$suid = trim((string) ($_POST['stationID'] ?? ''));
 
-$username = $mysqli->real_escape_string($_POST['user_name']);
-$password = $mysqli->real_escape_string($_POST['user_password']);
-$ip = $_POST['ip'];
-$suid = $_POST['stationID'];
-$user = getUserByEmailAndPassword($username, $password);
-
-// #######################################################################
-// ####################### FINAL GET ID ##################################
-// #######################################################################
-
-if ($user != false) {
-	if($user['accesslevel'] == "banned") {
-		$response['message'] = "Your account has been banned. For further information regarding the ban of your account or to submit a Ban Appeal, contact a member of CSR Staff.";
-	} else {
-		$response['message'] = "success";
-	}
+if ($username === '' || $password === '') {
+    logSecurityEvent($mysqli, 'api_auth', $ipAddress);
+    echo json_encode(['message' => 'Username and password are required.']);
+    exit;
 }
-else {
-	$response['message'] = "Account does not exist or password was incorrect";
+
+$user = findUserByUsername($mysqli, $username);
+
+if (!$user || !verifyPassword($password, $user['password_hash'])) {
+    logSecurityEvent($mysqli, 'api_auth', $ipAddress);
+    echo json_encode(['message' => 'Account does not exist or password was incorrect']);
+    exit;
 }
-echo json_encode($response);
 
-// #######################################################################
-// ####################### AUTHENTICATION LOGS ###########################
-// #######################################################################
+if (!requireVerifiedAccount($user)) {
+    logSecurityEvent($mysqli, 'api_auth', $ipAddress);
+    echo json_encode(['message' => 'Email verification pending']);
+    exit;
+}
 
-$auth_content = '[' . date('m/d/Y h:i:s a') . '] ' . 'Username: ' . $username . ', Station ID: ' . $suid . ', IP: ' . $ip . "\n";
+if (strcasecmp($user['accesslevel'], 'banned') === 0) {
+    logSecurityEvent($mysqli, 'api_auth', $ipAddress);
+    echo json_encode(['message' => 'Your account has been banned. Contact CSR staff for more information.']);
+    exit;
+}
 
-// To enable logging, give the chdir function the absolute path to your webroot directory and uncomment the following two lines.
-// Also make sure that your apache2 user owns the webroot directory and has write permissions.
+logSecurityEvent($mysqli, 'api_auth', $ipAddress);
 
-#chdir('WEBROOT_DIRECTORY_GOES_HERE'); // If you're running VM 2.1, chdir should be /srv/www/htdocs
-#file_put_contents('logs/auth_log.txt', $auth_content, FILE_APPEND);
+echo json_encode(['message' => 'success']);
+
+$authContent = sprintf('[%s] Username: %s, Station ID: %s, IP: %s%s',
+    date('m/d/Y h:i:s a'),
+    $username,
+    $suid,
+    $ipAddress,
+    PHP_EOL
+);
+
+// Optional file logging can be re-enabled by configuring filesystem permissions.
+// file_put_contents(__DIR__ . '/logs/auth_log.txt', $authContent, FILE_APPEND);
 
 die();
-
-// #######################################################################
-// ####################### END OF FILE ###################################
-// #######################################################################
-?>

--- a/changepassword.php
+++ b/changepassword.php
@@ -1,124 +1,159 @@
 <?php
-	session_start();
-	if(! isset($_SESSION['user'])) {
-		$_SESSION['urlredirect'] = basename($_SERVER['PHP_SELF']);
-		header("Location: form_login.php");
-	}
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
+
+ensureSessionStarted();
+
+if (!isset($_SESSION['user'])) {
+    $_SESSION['urlredirect'] = basename($_SERVER['PHP_SELF']);
+    header('Location: form_login.php');
+    exit;
+}
+
+$csrfToken = getCsrfToken();
+$config = require __DIR__ . '/includes/config.php';
+
+$usernames = [];
+$stmt = $mysqli->prepare('SELECT user_id, username FROM user_account ORDER BY username ASC');
+$stmt->execute();
+$result = $stmt->get_result();
+while ($row = $result->fetch_assoc()) {
+    $usernames[] = $row;
+}
 ?>
-<html>
-	<head>
-		<meta name = "viewport" content = "width = device-width, initial-scale = 1, minimum-scale=1, maximum-scale=1, user-scalable=no">
-			<title>Change Password</title>
-	<style>
-	div.container {
-    width: 90%;
-    border: none;
-}
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Update Password | <?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?></title>
+    <link rel="stylesheet" href="stylesheet.css">
+    <style>
+        body {
+            background-image: url("/images/grevious.jpg");
+            background-color: #010409;
+            background-size: cover;
+            background-attachment: fixed;
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            color: #e2e8f0;
+        }
 
-header, footer {
-    padding: 1em;
-    color: white;
-    background-color: none;
-    clear: left;
-    text-align: center;
-}
+        .password-card {
+            max-width: 520px;
+            margin: 4rem auto;
+            padding: 2.5rem;
+            background: rgba(2, 6, 23, 0.88);
+            border-radius: 20px;
+            box-shadow: 0 28px 52px rgba(0, 0, 0, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+        }
 
-nav {
-    float: left;
-    max-width: 160px;
-    margin: 0;
-    padding: 1em;
-}
+        h1 {
+            text-align: center;
+            margin-bottom: 0.35rem;
+            letter-spacing: 0.08em;
+        }
 
-nav ul {
-    list-style-type: none;
-    padding: 0;
-}
-   
-nav ul a {
-    text-decoration: none;
-}
+        p.subtitle {
+            text-align: center;
+            color: #cbd5e1;
+            margin-bottom: 2rem;
+        }
 
-article {
-    margin-left: 170px;
-    border-left: none;
-    padding: 1em;
-    overflow: hidden;
-}
-body  {
-    background-color: black;
-    background-image: url("/images/grevious.jpg");
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-position: center;
-    background-size: cover;
-}
-a:link {
-    color: green;
-    background-color: transparent;
-    text-decoration: none;
-}
-a:visited {
-    color: orange;
-    background-color: transparent;
-    text-decoration: none;
-}
-a:hover {
-    color: red;
-    background-color: transparent;
-    text-decoration: underline;
-}
-a:active {
-    color: yellow;
-    background-color: transparent;
-    text-decoration: underline;
-}    
-</style>
-	</head>
-		<body>
-	<center>
-		<form action='post_changepassword.php' method='post' border='0'>
-		<table>
-			<tr>
-				<td><b><p style="color:white;">Username</p></b></td>
-				<td><select name="username">
-<?php
-			include 'includes/db_connect.php';
-			$usernamesql = "SELECT * FROM user_account ORDER BY user_id";
-			$usernameresult = $mysqli->query($usernamesql);
-			$usernamejson = array();
-			if($usernameresult->num_rows) {
-				$ln = 0;
-				while($usernamerow=$usernameresult->fetch_assoc()) {
-					$usernamejson[] = $usernamerow;
-					if(strcasecmp($_SESSION['username'], $usernamejson[$ln]['username']) == 0) {
-						echo '					<option value="'.$usernamejson[$ln]['username'].'"';
-						echo ' selected="selected"';
-						echo '>'.$usernamejson[$ln]['username'].'</option>'.PHP_EOL;
-					}
-					else if($_SESSION['accesslevel'] == "superadmin") {
-						echo '					<option value="'.$usernamejson[$ln]['username'].'"';
-						echo '>'.$usernamejson[$ln]['username'].'</option>'.PHP_EOL;
-					}
-					$ln++;
-				}
-			} ?>
-			</select></td>
-		</tr>
-		<tr>
-			<td><b><p style="color:white;">New Password</p></b></td>
-			<td><input id='realpassword' type='realpassword' name='password' /></td>
-		</tr>
-		<tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr><tr></tr>
-		<tr>
-			<td></td>
-			<td>
-				<input type='hidden' name='action' value='update' />
-				<input type='submit' value='Save' id="save" />
-			</td>
-		</tr>
-		</table>
-		</form>
-	</center>
-		</body>
+        label {
+            display: block;
+            font-size: 0.8rem;
+            letter-spacing: 0.08em;
+            margin-bottom: 0.35rem;
+            color: #94a3b8;
+            text-transform: uppercase;
+        }
+
+        select,
+        input[type="password"] {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            margin-bottom: 1.25rem;
+            border-radius: 10px;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            background: rgba(15, 23, 42, 0.85);
+            color: #f8fafc;
+            font-size: 1rem;
+        }
+
+        button[type="submit"] {
+            width: 100%;
+            padding: 0.9rem 1rem;
+            border-radius: 999px;
+            border: none;
+            font-size: 1.05rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            background: linear-gradient(135deg, #f97316, #ef4444);
+            color: #0f172a;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button[type="submit"]:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 20px 32px rgba(249, 115, 22, 0.45);
+        }
+
+        .actions {
+            display: flex;
+            justify-content: space-between;
+            margin-top: 1.5rem;
+        }
+
+        .actions a {
+            color: #38bdf8;
+        }
+
+        .actions a:hover {
+            color: #34d399;
+        }
+
+        .requirements {
+            font-size: 0.85rem;
+            color: #cbd5e1;
+            margin-top: -0.75rem;
+            margin-bottom: 1.75rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="password-card">
+        <h1>Reset Password</h1>
+        <p class="subtitle">Keep your credentials secure with a strong passphrase.</p>
+        <form action="post_changepassword.php" method="post" autocomplete="off">
+            <label for="username">Account</label>
+            <select name="username" id="username" required>
+                <?php foreach ($usernames as $account) :
+                    $selected = (strcasecmp($_SESSION['username'], $account['username']) === 0) ? 'selected' : '';
+                    if ($selected || strcasecmp($_SESSION['accesslevel'] ?? '', 'superadmin') === 0) : ?>
+                        <option value="<?php echo htmlspecialchars($account['username'], ENT_QUOTES, 'UTF-8'); ?>" <?php echo $selected; ?>>
+                            <?php echo htmlspecialchars($account['username'], ENT_QUOTES, 'UTF-8'); ?>
+                        </option>
+                    <?php endif;
+                endforeach; ?>
+            </select>
+            <label for="new_password">New Password</label>
+            <input id="new_password" type="password" name="realpassword" required minlength="12" autocomplete="new-password">
+            <div class="requirements">Minimum 12 characters with uppercase, lowercase, number and symbol.</div>
+            <input type="hidden" name="action" value="update">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+            <button type="submit">Update Password</button>
+        </form>
+        <div class="actions">
+            <a href="/index.php">Back to Control Center</a>
+            <a href="/logout.php">Logout</a>
+        </div>
+    </div>
+</body>
 </html>

--- a/create_database_table.sql
+++ b/create_database_table.sql
@@ -1,38 +1,78 @@
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
 
-
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8mb4 */;
 
 -- --------------------------------------------------------
-
---
 -- Table structure for table `user_account`
---
+-- --------------------------------------------------------
 
 CREATE TABLE `user_account` (
   `user_id` int(11) NOT NULL,
-  `accesslevel` varchar(255) NOT NULL,
+  `accesslevel` varchar(255) NOT NULL DEFAULT 'standard',
   `username` varchar(255) NOT NULL,
-  `password_salt` varchar(255) NOT NULL,
-  `password_hash` varchar(255) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+  `email` varchar(255) NOT NULL,
+  `password_hash` varchar(255) NOT NULL,
+  `email_verification_token` varchar(255) DEFAULT NULL,
+  `email_verified_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
---
 -- Indexes for table `user_account`
---
 ALTER TABLE `user_account`
-  ADD UNIQUE KEY `user_id` (`user_id`),
-  ADD UNIQUE KEY `username` (`username`);
+  ADD PRIMARY KEY (`user_id`),
+  ADD UNIQUE KEY `username` (`username`),
+  ADD UNIQUE KEY `email` (`email`);
 
---
 -- AUTO_INCREMENT for table `user_account`
---
 ALTER TABLE `user_account`
   MODIFY `user_id` int(11) NOT NULL AUTO_INCREMENT;
+
+-- --------------------------------------------------------
+-- Table structure for table `auth_events`
+-- --------------------------------------------------------
+
+CREATE TABLE `auth_events` (
+  `id` int(11) NOT NULL,
+  `action` varchar(50) NOT NULL,
+  `ip_address` varchar(45) NOT NULL,
+  `user_agent` varchar(255) DEFAULT NULL,
+  `network_host` varchar(255) DEFAULT NULL,
+  `created_at` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `auth_events`
+  ADD PRIMARY KEY (`id`),
+  ADD INDEX `idx_action_created` (`action`, `created_at`),
+  ADD INDEX `idx_ip_created` (`ip_address`, `created_at`);
+
+ALTER TABLE `auth_events`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+-- --------------------------------------------------------
+-- Table structure for table `banned_networks`
+-- --------------------------------------------------------
+
+CREATE TABLE `banned_networks` (
+  `id` int(11) NOT NULL,
+  `ip_address` varchar(45) NOT NULL,
+  `network_host` varchar(255) DEFAULT NULL,
+  `reason` varchar(255) DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `banned_networks`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uniq_ip_address` (`ip_address`);
+
+ALTER TABLE `banned_networks`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/form_login.php
+++ b/form_login.php
@@ -1,82 +1,144 @@
 <?php
-session_start();
-?><html>
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+
+ensureSessionStarted();
+$csrfToken = getCsrfToken();
+$config = require __DIR__ . '/includes/config.php';
+?>
+<!doctype html>
+<html lang="en">
 <head>
-<title>SWG:Source | Login</title>
-<meta name = "viewport" content = "width = device-width">
-<meta name = "viewport" content = "initial-scale = 1.0">
-<style>
-	div.container {
-    width: 90%;
-    border: none;
-}
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?> | Secure Login</title>
+    <link rel="stylesheet" href="stylesheet.css">
+    <style>
+        body {
+            background-image: url("/images/mfalcon.jpg");
+            background-color: #010409;
+            background-size: cover;
+            background-attachment: fixed;
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            color: #f8fafc;
+        }
 
-header, footer {
-    padding: 1em;
-    color: white;
-    background-color: none;
-    clear: left;
-    text-align: center;
-}
+        .login-container {
+            max-width: 420px;
+            margin: 5rem auto;
+            padding: 2.75rem 2.5rem;
+            background: rgba(2, 6, 23, 0.88);
+            border-radius: 18px;
+            box-shadow: 0 28px 50px rgba(0, 0, 0, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            text-align: center;
+        }
 
-nav {
-    float: left;
-    max-width: 160px;
-    margin: 0;
-    padding: 1em;
-}
+        .login-container img {
+            width: 180px;
+            margin-bottom: 1.5rem;
+        }
 
-nav ul {
-    list-style-type: none;
-    padding: 0;
-}
-   
-nav ul a {
-    text-decoration: none;
-}
+        .login-container h1 {
+            font-size: 1.9rem;
+            letter-spacing: 0.1em;
+            margin-bottom: 0.25rem;
+        }
 
-article {
-    margin-left: 170px;
-    border-left: none;
-    padding: 1em;
-    overflow: hidden;
-}
-body  {
-    background-color: black;
-    background-image: url("/images/mfalcon.jpg");
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-position: center;
-    background-size: cover;
-}
-a:link {
-    color: green;
-    background-color: transparent;
-    text-decoration: none;
-}
-a:visited {
-    color: orange;
-    background-color: transparent;
-    text-decoration: none;
-}
-a:hover {
-    color: red;
-    background-color: transparent;
-    text-decoration: underline;
-}
-a:active {
-    color: yellow;
-    background-color: transparent;
-    text-decoration: underline;
-}    
-</style>
+        .login-container p {
+            margin-top: 0;
+            color: #cbd5e1;
+            font-size: 0.95rem;
+        }
+
+        label {
+            display: block;
+            text-align: left;
+            font-size: 0.8rem;
+            letter-spacing: 0.08em;
+            margin-bottom: 0.35rem;
+            color: #94a3b8;
+            text-transform: uppercase;
+        }
+
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            margin-bottom: 1rem;
+            border-radius: 10px;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            background: rgba(15, 23, 42, 0.85);
+            color: #e2e8f0;
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        input[type="text"]:focus,
+        input[type="password"]:focus {
+            border-color: #38bdf8;
+            box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+            outline: none;
+        }
+
+        button[type="submit"] {
+            width: 100%;
+            padding: 0.9rem 1rem;
+            border-radius: 999px;
+            border: none;
+            font-size: 1.05rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            background: linear-gradient(135deg, #2563eb, #06b6d4);
+            color: #0f172a;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button[type="submit"]:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 18px 30px rgba(37, 99, 235, 0.45);
+        }
+
+        .aux-links {
+            margin-top: 1.75rem;
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.85rem;
+            color: #94a3b8;
+        }
+
+        .aux-links a {
+            color: #38bdf8;
+        }
+
+        .aux-links a:hover {
+            color: #34d399;
+        }
+    </style>
 </head>
 <body>
-<center><img src="images/swgsource.png" alt="" width=200/></center>
-<form method="post" action="post_login.php">
-	<center><b><p style="color:white;">Username: <input name="username" type="text"></p></b>
-		<b><p style="color:white;">Password: <input name="password" type="password"></p></b>
-<input name="submit" type="submit" value="Submit"></center>
-</form>
+    <div class="login-container">
+        <img src="/images/swgsource.png" alt="SWG Source Logo" width="180" height="180">
+        <h1>Welcome Back</h1>
+        <p>Authenticate to access command consoles, mission updates, and account tools.</p>
+        <form method="post" action="post_login.php" autocomplete="on">
+            <label for="username">Username</label>
+            <input id="username" name="username" type="text" required autocomplete="username" maxlength="32">
+            <label for="password">Password</label>
+            <input id="password" name="password" type="password" required autocomplete="current-password">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+            <div>
+                <button type="submit">Engage Secure Login</button>
+            </div>
+        </form>
+        <div class="aux-links">
+            <span><a href="/addnewuser.php">Need an account?</a></span>
+            <span><a href="/index.php">Return to main hub</a></span>
+        </div>
+    </div>
 </body>
 </html>

--- a/includes/auth_functions.php
+++ b/includes/auth_functions.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+function findUserByUsername(mysqli $db, string $username): ?array
+{
+    $stmt = $db->prepare('SELECT * FROM user_account WHERE username = ? LIMIT 1');
+    $stmt->bind_param('s', $username);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $user = $result->fetch_assoc();
+    return $user ?: null;
+}
+
+function findUserByEmail(mysqli $db, string $email): ?array
+{
+    $stmt = $db->prepare('SELECT * FROM user_account WHERE email = ? LIMIT 1');
+    $stmt->bind_param('s', $email);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $user = $result->fetch_assoc();
+    return $user ?: null;
+}
+
+function verifyPassword(string $password, string $hash): bool
+{
+    return password_verify($password, $hash);
+}
+
+function requireVerifiedAccount(array $user): bool
+{
+    return !empty($user['email_verified_at']);
+}
+
+function markEmailVerified(mysqli $db, int $userId): void
+{
+    $timestamp = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+    $null = null;
+    $stmt = $db->prepare('UPDATE user_account SET email_verified_at = ?, email_verification_token = ? WHERE user_id = ?');
+    $stmt->bind_param('ssi', $timestamp, $null, $userId);
+    $stmt->execute();
+}

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'site_name' => 'SWG Source Server',
+    'base_url' => rtrim(getenv('SWG_BASE_URL') ?: 'http://localhost', '/'),
+    'mail_from' => getenv('SWG_MAIL_FROM') ?: 'no-reply@swgsource.com',
+    'registration' => [
+        'max_attempts' => (int) (getenv('SWG_REG_MAX_ATTEMPTS') ?: 5),
+        'interval_seconds' => (int) (getenv('SWG_REG_INTERVAL_SECONDS') ?: 3600),
+    ],
+    'login' => [
+        'max_attempts' => (int) (getenv('SWG_LOGIN_MAX_ATTEMPTS') ?: 10),
+        'interval_seconds' => (int) (getenv('SWG_LOGIN_INTERVAL_SECONDS') ?: 900),
+    ],
+];

--- a/includes/db_connect.php
+++ b/includes/db_connect.php
@@ -1,11 +1,12 @@
 <?php
-$host = "localhost";
-$username = "root";
-$password = "swg";
-$db_name = "swgusers";
-$mysqli = new mysqli($host, $username, $password, $db_name);
-if(mysqli_connect_errno()) {
-    echo "Error: Could not connect to database.";
-    exit;
-}
-?>
+declare(strict_types=1);
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$host = getenv('SWG_DB_HOST') ?: 'localhost';
+$username = getenv('SWG_DB_USER') ?: 'root';
+$password = getenv('SWG_DB_PASSWORD') ?: 'swg';
+$dbName = getenv('SWG_DB_NAME') ?: 'swgusers';
+
+$mysqli = new mysqli($host, $username, $password, $dbName);
+$mysqli->set_charset('utf8mb4');

--- a/includes/security.php
+++ b/includes/security.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Ensure we are operating with a secure PHP session.
+ */
+function ensureSessionStarted(): void
+{
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        return;
+    }
+
+    $secure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'domain' => '',
+        'secure' => $secure,
+        'httponly' => true,
+        'samesite' => 'Strict',
+    ]);
+
+    session_start();
+}
+
+function getCsrfToken(): string
+{
+    ensureSessionStarted();
+
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+
+    return $_SESSION['csrf_token'];
+}
+
+function validateCsrfToken(?string $token): bool
+{
+    ensureSessionStarted();
+
+    if (empty($_SESSION['csrf_token']) || empty($token)) {
+        return false;
+    }
+
+    return hash_equals($_SESSION['csrf_token'], $token);
+}
+
+function currentIpAddress(): string
+{
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        return $ip;
+    }
+
+    return filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '0.0.0.0';
+}
+
+function truncateForStorage(string $value, int $length = 250): string
+{
+    $clean = preg_replace('/[\x00-\x1F\x7F]/', '', $value) ?? '';
+    $clean = trim($clean);
+
+    if ($clean === '') {
+        return 'unknown';
+    }
+
+    if (function_exists('mb_substr')) {
+        return mb_substr($clean, 0, $length, 'UTF-8');
+    }
+
+    return substr($clean, 0, $length);
+}
+
+function currentUserAgent(): string
+{
+    $agent = $_SERVER['HTTP_USER_AGENT'] ?? 'unknown';
+    return truncateForStorage($agent);
+}
+
+function networkOwnerFromIp(string $ipAddress): string
+{
+    if (!filter_var($ipAddress, FILTER_VALIDATE_IP)) {
+        return 'unknown';
+    }
+
+    $host = @gethostbyaddr($ipAddress);
+
+    if ($host === false || $host === $ipAddress) {
+        return 'unknown';
+    }
+
+    return truncateForStorage($host);
+}
+
+function logSecurityEvent(mysqli $db, string $action, string $ipAddress): void
+{
+    $createdAt = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+    $userAgent = currentUserAgent();
+    $networkHost = networkOwnerFromIp($ipAddress);
+
+    $stmt = $db->prepare('INSERT INTO auth_events (action, ip_address, user_agent, network_host, created_at) VALUES (?, ?, ?, ?, ?)');
+    $stmt->bind_param('sssss', $action, $ipAddress, $userAgent, $networkHost, $createdAt);
+    $stmt->execute();
+}
+
+function hasExceededRateLimit(mysqli $db, string $action, string $ipAddress, int $maxAttempts, int $intervalSeconds): bool
+{
+    $threshold = (new DateTimeImmutable('now', new DateTimeZone('UTC')))
+        ->sub(new DateInterval('PT' . $intervalSeconds . 'S'))
+        ->format('Y-m-d H:i:s');
+
+    $stmt = $db->prepare('SELECT COUNT(*) FROM auth_events WHERE action = ? AND ip_address = ? AND created_at >= ?');
+    $stmt->bind_param('sss', $action, $ipAddress, $threshold);
+    $stmt->execute();
+    $stmt->bind_result($count);
+    $stmt->fetch();
+
+    return (int) $count >= $maxAttempts;
+}
+
+function purgeOldSecurityEvents(mysqli $db, int $retentionDays = 30): void
+{
+    $threshold = (new DateTimeImmutable('now', new DateTimeZone('UTC')))
+        ->sub(new DateInterval('P' . max($retentionDays, 1) . 'D'))
+        ->format('Y-m-d H:i:s');
+
+    $stmt = $db->prepare('DELETE FROM auth_events WHERE created_at < ?');
+    $stmt->bind_param('s', $threshold);
+    $stmt->execute();
+}
+
+function findBannedNetwork(mysqli $db, string $ipAddress): ?array
+{
+    if (!filter_var($ipAddress, FILTER_VALIDATE_IP)) {
+        return null;
+    }
+
+    $stmt = $db->prepare('SELECT ip_address, network_host, reason FROM banned_networks WHERE ip_address = ? LIMIT 1');
+    $stmt->bind_param('s', $ipAddress);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $record = $result->fetch_assoc();
+
+    if (!$record) {
+        return null;
+    }
+
+    if (empty($record['network_host']) || $record['network_host'] === 'unknown') {
+        $resolved = networkOwnerFromIp($ipAddress);
+
+        if ($resolved !== 'unknown') {
+            $update = $db->prepare('UPDATE banned_networks SET network_host = ?, updated_at = CURRENT_TIMESTAMP WHERE ip_address = ?');
+            $update->bind_param('ss', $resolved, $ipAddress);
+            $update->execute();
+            $record['network_host'] = $resolved;
+        } else {
+            $record['network_host'] = 'unknown';
+        }
+    }
+
+    return $record;
+}

--- a/logout.php
+++ b/logout.php
@@ -1,9 +1,16 @@
 <?php
-session_start();
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+
+ensureSessionStarted();
+
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+}
+
 session_destroy();
-header("Location: index.php");
-?>
-<html><head>
-<meta name = "viewport" content = "width = device-width">
-<meta name = "viewport" content = "initial-scale = 1.0">
-</head></html>
+header('Location: index.php');
+exit;

--- a/newuserpost.php
+++ b/newuserpost.php
@@ -1,42 +1,247 @@
 <?php
-session_start();
-?>
-<html><head>
-<meta name = "viewport" content = "width = device-width">
-<meta name = "viewport" content = "initial-scale = 1.0">
-<?php
-$action = isset($_POST['action']) ? $_POST['action'] : "";
+declare(strict_types=1);
 
-if($action=='create') {
-    include 'includes/db_connect.php';
-	function HashPassword($password)
-	{
-		$random = '';
-		$salt = sha1(rand());
-        $salt = substr($salt, 0, 10);
-        $encrypted = base64_encode(sha1($password . $salt, true) . $salt);
-        $hash = array("salt" => $salt, "encrypted" => $encrypted);
-        return $hash;
-	}
-	$passwordHash = HashPassword($_POST['realpassword']);
-	$passwordSalt = $passwordHash['salt'];
-	$passwordEncrypted = $passwordHash['encrypted'];
-    $query = "insert into user_account
-	set
-	username = '".$mysqli->real_escape_string($_POST['useraccountname'])."',
-	password_hash = '".$mysqli->real_escape_string($passwordEncrypted)."',
-	password_salt = '".$mysqli->real_escape_string($passwordSalt)."',
-    accesslevel = 'standard'";
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
 
-    if( $mysqli->query($query) ) {
-		echo '<script>';
-		echo 'window.location.assign("index.php");';
-        echo '</script>';
-	}
-	else {
-		printf($mysqli->error);
-	}
-	$mysqli->close();
+ensureSessionStarted();
+$config = require __DIR__ . '/includes/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: addnewuser.php');
+    exit;
 }
-?>
-</head></html>
+
+if (!validateCsrfToken($_POST['csrf_token'] ?? null)) {
+    http_response_code(400);
+    $errors = ['Security token mismatch. Please refresh the page and try again.'];
+    renderResponse($config, $errors);
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+if ($action !== 'create') {
+    http_response_code(400);
+    $errors = ['Invalid registration request.'];
+    renderResponse($config, $errors);
+    exit;
+}
+
+purgeOldSecurityEvents($mysqli);
+$ipAddress = currentIpAddress();
+$banRecord = findBannedNetwork($mysqli, $ipAddress);
+$banReason = $banRecord['reason'] ?? '';
+
+if ($banRecord) {
+    logSecurityEvent($mysqli, 'ip_blocked', $ipAddress);
+    $message = 'Access from this network has been blocked by ' . $config['site_name'] . ' security.';
+
+    if ($banReason !== '') {
+        $message .= ' Reason: ' . $banReason . '.';
+    }
+
+    renderResponse($config, [$message]);
+    exit;
+}
+
+$maxAttempts = max(1, $config['registration']['max_attempts'] ?? 5);
+$intervalSeconds = max(60, $config['registration']['interval_seconds'] ?? 3600);
+
+if (hasExceededRateLimit($mysqli, 'register', $ipAddress, $maxAttempts, $intervalSeconds)) {
+    $errors = ['Too many registration attempts detected. Please try again later or contact an administrator.'];
+    renderResponse($config, $errors);
+    exit;
+}
+
+$username = trim((string) ($_POST['useraccountname'] ?? ''));
+$email = trim((string) ($_POST['email'] ?? ''));
+$password = (string) ($_POST['realpassword'] ?? '');
+$confirmPassword = (string) ($_POST['confirmpassword'] ?? '');
+$acceptedTerms = ($_POST['terms'] ?? '') === 'yes';
+
+$errors = [];
+
+if (!preg_match('/^[A-Za-z0-9_-]{4,32}$/', $username)) {
+    $errors[] = 'Account names must be 4-32 characters and can only include letters, numbers, underscores, or hyphens.';
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $errors[] = 'Please provide a valid email address.';
+}
+
+if (strlen($email) > 190) {
+    $errors[] = 'Email addresses must be 190 characters or fewer.';
+}
+
+if ($password !== $confirmPassword) {
+    $errors[] = 'Password confirmation does not match.';
+}
+
+if (!preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{12,}$/', $password)) {
+    $errors[] = 'Passwords must be at least 12 characters long and include upper- and lower-case letters, a number, and a symbol.';
+}
+
+if (!$acceptedTerms) {
+    $errors[] = 'You must accept the community code of conduct before creating an account.';
+}
+
+if (findUserByUsername($mysqli, $username)) {
+    $errors[] = 'That account name is already in use.';
+}
+
+if (findUserByEmail($mysqli, $email)) {
+    $errors[] = 'An account with that email address already exists.';
+}
+
+if (!empty($errors)) {
+    logSecurityEvent($mysqli, 'register', $ipAddress);
+    renderResponse($config, $errors);
+    exit;
+}
+
+$passwordHash = password_hash($password, PASSWORD_DEFAULT);
+$verificationToken = bin2hex(random_bytes(32));
+$accessLevel = 'standard';
+
+$stmt = $mysqli->prepare('INSERT INTO user_account (accesslevel, username, email, password_hash, email_verification_token) VALUES (?, ?, ?, ?, ?)');
+$stmt->bind_param('sssss', $accessLevel, $username, $email, $passwordHash, $verificationToken);
+$stmt->execute();
+
+logSecurityEvent($mysqli, 'register', $ipAddress);
+
+$verificationLink = $config['base_url'] . '/verify_email.php?token=' . urlencode($verificationToken);
+$subject = 'Verify your ' . $config['site_name'] . ' account';
+$message = <<<MAIL
+Greetings Commander {$username},
+
+Welcome to {$config['site_name']}! Please confirm your email address to activate your account:
+{$verificationLink}
+
+If you did not request this account, ignore this email and the request will expire.
+
+For the Empire,
+{$config['site_name']} Security Team
+MAIL;
+
+$headers = 'From: ' . $config['mail_from'] . "\r\n" . 'Content-Type: text/plain; charset=UTF-8';
+$mailSent = @mail($email, $subject, $message, $headers);
+
+renderResponse($config, [], $mailSent);
+exit;
+
+function renderResponse(array $config, array $errors, bool $mailSent = false): void
+{
+    http_response_code(empty($errors) ? 200 : 422);
+    ?>
+    <!doctype html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Registration Status | <?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?></title>
+        <link rel="stylesheet" href="stylesheet.css">
+        <style>
+            body {
+                background: radial-gradient(circle at top, #0f172a, #020617 65%);
+                color: #f8fafc;
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                margin: 0;
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 2rem;
+            }
+
+            .status-card {
+                background: rgba(15, 23, 42, 0.92);
+                border-radius: 18px;
+                max-width: 560px;
+                width: 100%;
+                padding: 2.5rem;
+                box-shadow: 0 30px 60px rgba(2, 6, 23, 0.6);
+                border: 1px solid rgba(148, 163, 184, 0.2);
+            }
+
+            h1 {
+                margin-top: 0;
+                font-size: 2rem;
+                text-align: center;
+                letter-spacing: 0.1em;
+            }
+
+            .status-card ul {
+                list-style: none;
+                padding: 0;
+            }
+
+            .status-card li {
+                background: rgba(220, 38, 38, 0.18);
+                border: 1px solid rgba(248, 113, 113, 0.4);
+                border-radius: 10px;
+                padding: 0.85rem 1rem;
+                margin-bottom: 0.75rem;
+            }
+
+            .success {
+                background: rgba(13, 148, 136, 0.18);
+                border: 1px solid rgba(45, 212, 191, 0.45);
+                color: #ccfbf1;
+                border-radius: 12px;
+                padding: 1rem 1.25rem;
+                font-size: 1rem;
+                line-height: 1.6;
+            }
+
+            .actions {
+                text-align: center;
+                margin-top: 2rem;
+            }
+
+            a.button {
+                display: inline-block;
+                padding: 0.75rem 2.5rem;
+                border-radius: 999px;
+                text-decoration: none;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                font-weight: 600;
+                background: linear-gradient(135deg, #3b82f6, #22d3ee);
+                color: #0f172a;
+                transition: transform 0.15s ease, box-shadow 0.15s ease;
+            }
+
+            a.button:hover {
+                transform: translateY(-1px);
+                box-shadow: 0 18px 35px rgba(59, 130, 246, 0.35);
+            }
+        </style>
+    </head>
+    <body>
+        <div class="status-card">
+            <?php if (!empty($errors)) : ?>
+                <h1>Registration Needs Attention</h1>
+                <p>Please review the following items:</p>
+                <ul>
+                    <?php foreach ($errors as $error) : ?>
+                        <li><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else : ?>
+                <h1>Registration Received</h1>
+                <div class="success">
+                    <p>Your account request has been recorded. <?php echo $mailSent
+                        ? 'Check your inbox for a verification link to activate your access.'
+                        : 'We were unable to send a verification email automatically. Please contact support with your username to complete activation.'; ?></p>
+                </div>
+            <?php endif; ?>
+            <div class="actions">
+                <a class="button" href="/addnewuser.php">Back to Registration</a>
+                <a class="button" href="/form_login.php" style="margin-left: 1rem;">Go to Login</a>
+            </div>
+        </div>
+    </body>
+    </html>
+    <?php
+}

--- a/post_changepassword.php
+++ b/post_changepassword.php
@@ -1,58 +1,168 @@
 <?php
-session_start();
-if(! isset($_SESSION['user'])) {
-	header("Location: form_login.php"); //if we aren't logged in, redirect to login!
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
+
+ensureSessionStarted();
+$config = require __DIR__ . '/includes/config.php';
+
+if (!isset($_SESSION['user'])) {
+    header('Location: form_login.php');
+    exit;
 }
-?>
-<html><head>
-<meta name = "viewport" content = "width = device-width">
-<meta name = "viewport" content = "initial-scale = 1.0">
-<?php
-$action = isset($_POST['action']) ? $mysqli->real_escape_string($_POST['action']) : "";
-$username = $mysqli->real_escape_string($_POST['username']);
-if(strcasecmp($_SESSION['username'], $usernamejson[$ln]['username']) != 0)
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: changepassword.php');
+    exit;
+}
+
+if (!validateCsrfToken($_POST['csrf_token'] ?? null)) {
+    renderPasswordResponse($config, ['Security validation failed. Please try again.']);
+    exit;
+}
+
+$username = trim((string) ($_POST['username'] ?? ''));
+$newPassword = (string) ($_POST['realpassword'] ?? '');
+$errors = [];
+
+if ($username === '') {
+    $errors[] = 'A valid account must be selected.';
+}
+
+if (!preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{12,}$/', $newPassword)) {
+    $errors[] = 'Passwords must be at least 12 characters and include upper- and lower-case letters, a number, and a symbol.';
+}
+
+$user = $username !== '' ? findUserByUsername($mysqli, $username) : null;
+
+if (!$user) {
+    $errors[] = 'The selected account could not be found.';
+}
+
+$isSuperAdmin = strcasecmp($_SESSION['accesslevel'] ?? '', 'superadmin') === 0;
+
+if ($user && !$isSuperAdmin && strcasecmp($_SESSION['username'] ?? '', $user['username']) !== 0) {
+    $errors[] = 'You can only change your own password.';
+}
+
+if (!empty($errors)) {
+    renderPasswordResponse($config, $errors);
+    exit;
+}
+
+$passwordHash = password_hash($newPassword, PASSWORD_DEFAULT);
+
+$stmt = $mysqli->prepare('UPDATE user_account SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE username = ?');
+$stmt->bind_param('ss', $passwordHash, $user['username']);
+$stmt->execute();
+
+logSecurityEvent($mysqli, 'password_reset', currentIpAddress());
+
+renderPasswordResponse($config, []);
+exit;
+
+function renderPasswordResponse(array $config, array $errors): void
 {
-	//error - trying to update password for someone that isn't ourself
-	if($_SESSION['accesslevel'] != "superadmin") {
-		//we can continue, we are superadmin
-	}
-	else
-	{
-		echo "Error - You can only change your own password.";
-		die();
-	}
-}
+    http_response_code(empty($errors) ? 200 : 422);
+    ?>
+    <!doctype html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Password Update</title>
+        <link rel="stylesheet" href="stylesheet.css">
+        <style>
+            body {
+                background: linear-gradient(145deg, #0f172a, #111827 60%, #020617);
+                color: #f8fafc;
+                margin: 0;
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+                padding: 2rem;
+            }
 
-if($action=='update') {
-    include 'includes/db_connect.php';
-    #do password hash here
-	function HashPassword($password)
-	{
-		$random = '';
-		$salt = sha1(rand());
-        $salt = substr($salt, 0, 10);
-        $encrypted = base64_encode(sha1($password . $salt, true) . $salt);
-        $hash = array("salt" => $salt, "encrypted" => $encrypted);
-        return $hash;
-	}
-	$passwordHash = HashPassword($_POST['realpassword']);
-	$passwordSalt = $passwordHash['salt'];
-	$passwordEncrypted = $passwordHash['encrypted'];
-    $query = "update user_account
-	set
-	password_hash = '".$mysqli->real_escape_string($passwordEncrypted)."',
-	password_salt = '".$mysqli->real_escape_string($passwordSalt)."'
-	WHERE username = '".$mysqli->real_escape_string($username)."'";
+            .status-card {
+                max-width: 520px;
+                width: 100%;
+                padding: 2.5rem;
+                background: rgba(15, 23, 42, 0.92);
+                border-radius: 18px;
+                box-shadow: 0 30px 55px rgba(2, 6, 23, 0.65);
+                border: 1px solid rgba(148, 163, 184, 0.2);
+            }
 
-    if( $mysqli->query($query) ) {
-		echo '<script>';
-		echo 'window.location.assign("index.php");';
-        echo '</script>';
-	}
-	else {
-		printf($mysqli->error);
-	}
-	$mysqli->close();
+            h1 {
+                margin-top: 0;
+                font-size: 1.9rem;
+                text-align: center;
+                letter-spacing: 0.1em;
+            }
+
+            ul {
+                list-style: none;
+                padding: 0;
+            }
+
+            li {
+                background: rgba(220, 38, 38, 0.16);
+                border: 1px solid rgba(248, 113, 113, 0.45);
+                padding: 0.85rem 1rem;
+                border-radius: 12px;
+                margin-bottom: 0.75rem;
+            }
+
+            .success {
+                background: rgba(13, 148, 136, 0.18);
+                border: 1px solid rgba(45, 212, 191, 0.45);
+                color: #ccfbf1;
+                border-radius: 12px;
+                padding: 1rem 1.25rem;
+            }
+
+            .actions {
+                text-align: center;
+                margin-top: 2rem;
+            }
+
+            a.button {
+                display: inline-block;
+                padding: 0.75rem 2.5rem;
+                border-radius: 999px;
+                text-decoration: none;
+                background: linear-gradient(135deg, #22d3ee, #0ea5e9);
+                color: #0f172a;
+                letter-spacing: 0.1em;
+                font-weight: 600;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="status-card">
+            <?php if (!empty($errors)) : ?>
+                <h1>Password Update Failed</h1>
+                <p>Please address the following items:</p>
+                <ul>
+                    <?php foreach ($errors as $error) : ?>
+                        <li><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else : ?>
+                <h1>Password Updated</h1>
+                <div class="success">
+                    <p>Your password has been refreshed. Use your new credentials on your next login.</p>
+                </div>
+            <?php endif; ?>
+            <div class="actions">
+                <a class="button" href="/index.php">Return to Dashboard</a>
+            </div>
+        </div>
+    </body>
+    </html>
+    <?php
 }
-?>
-</head></html>

--- a/post_login.php
+++ b/post_login.php
@@ -1,47 +1,174 @@
 <?php
-session_start();
-include 'includes/db_connect.php';
-$username = $mysqli->real_escape_string($_POST['username']);
-$password = $mysqli->real_escape_string($_POST['password']);
-$user = getUserByEmailAndPassword($username, $password);
-if($user == true) {
-	if(isset($_SESSION['urlredirect'])) {
-		$_SESSION['user'] = $mysqli->real_escape_string($_POST['username']);
-		$redirectName = $_SESSION['urlredirect'];
-		echo '<script>';
-		echo 'window.location.href="'.$redirectName.'"';
-		echo '</script>';
-	}
-	else {
-		header("Location: index.php");
-		$_SESSION['user'] = $mysqli->real_escape_string($_POST['username']);
-	}
-}
-else {
-	echo $mysqli->real_escape_string($_POST['username']), " does not exist or the password was incorrect";
-	echo '<p><a href="form_login.php">Log In</a>';
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
+
+ensureSessionStarted();
+$config = require __DIR__ . '/includes/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: form_login.php');
+    exit;
 }
 
-function getUserByEmailAndPassword($username, $password) {
-	global $mysqli;
-	$result = $mysqli->query("SELECT * FROM user_account WHERE username = '$username'") or die(mysql_error());
-	$no_of_rows = $result->num_rows;
-	if ($no_of_rows > 0) {
-		$result = $result->fetch_array();
-		$salt = $result['password_salt'];
-		$stored_hash = $result['password_hash'];
-		$hashtest = checkhashSSHA($salt, $password);
-		if ($hashtest == $stored_hash) {
-		    $_SESSION['accesslevel'] = $result['accesslevel'];
-			$_SESSION['username'] = $mysqli->real_escape_string($_POST['username']);
-			return true;
-        }
-    } else {
-        return false;
-    }
+if (!validateCsrfToken($_POST['csrf_token'] ?? null)) {
+    renderLoginResponse(['Security validation failed. Please try again.']);
+    exit;
 }
-function checkhashSSHA($salt, $password) {
-	$hash = base64_encode(sha1($password . $salt, true) . $salt);
-	return $hash;
+
+purgeOldSecurityEvents($mysqli);
+$ipAddress = currentIpAddress();
+$banRecord = findBannedNetwork($mysqli, $ipAddress);
+
+if ($banRecord) {
+    logSecurityEvent($mysqli, 'ip_blocked', $ipAddress);
+    $banReason = $banRecord['reason'] ?? '';
+    $reasonMessage = $banReason !== '' ? ' Reason: ' . $banReason . '.' : '';
+    renderLoginResponse(['Access from this network has been blocked by ' . $config['site_name'] . ' security.' . $reasonMessage]);
+    exit;
 }
-?>
+
+$maxAttempts = max(1, $config['login']['max_attempts'] ?? 10);
+$intervalSeconds = max(60, $config['login']['interval_seconds'] ?? 900);
+
+if (hasExceededRateLimit($mysqli, 'login', $ipAddress, $maxAttempts, $intervalSeconds)) {
+    renderLoginResponse(['Too many login attempts detected. Please wait before trying again.']);
+    exit;
+}
+
+$username = trim((string) ($_POST['username'] ?? ''));
+$password = (string) ($_POST['password'] ?? '');
+
+if ($username === '' || $password === '') {
+    logSecurityEvent($mysqli, 'login', $ipAddress);
+    renderLoginResponse(['Both username and password are required.']);
+    exit;
+}
+
+$user = findUserByUsername($mysqli, $username);
+
+if (!$user || !verifyPassword($password, $user['password_hash'])) {
+    logSecurityEvent($mysqli, 'login', $ipAddress);
+    renderLoginResponse(['Account does not exist or the password was incorrect.']);
+    exit;
+}
+
+if (!requireVerifiedAccount($user)) {
+    logSecurityEvent($mysqli, 'login', $ipAddress);
+    renderLoginResponse(['Email verification pending. Please use the verification link sent to your inbox before logging in.']);
+    exit;
+}
+
+if (strcasecmp($user['accesslevel'], 'banned') === 0) {
+    logSecurityEvent($mysqli, 'login', $ipAddress);
+    renderLoginResponse(['Your account has been banned. Contact a CSR team member for assistance.']);
+    exit;
+}
+
+logSecurityEvent($mysqli, 'login', $ipAddress);
+session_regenerate_id(true);
+
+$_SESSION['user_id'] = (int) $user['user_id'];
+$_SESSION['user'] = $user['username'];
+$_SESSION['username'] = $user['username'];
+$_SESSION['accesslevel'] = $user['accesslevel'];
+
+if (isset($_SESSION['urlredirect']) && $_SESSION['urlredirect'] !== '') {
+    $redirectName = $_SESSION['urlredirect'];
+    unset($_SESSION['urlredirect']);
+    header('Location: ' . $redirectName);
+    exit;
+}
+
+header('Location: index.php');
+exit;
+
+function renderLoginResponse(array $errors): void
+{
+    http_response_code(401);
+    ?>
+    <!doctype html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Login Error</title>
+        <link rel="stylesheet" href="stylesheet.css">
+        <style>
+            body {
+                background: linear-gradient(160deg, #0f172a 0%, #111827 45%, #020617 100%);
+                color: #f8fafc;
+                margin: 0;
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            }
+
+            .error-panel {
+                max-width: 480px;
+                width: 100%;
+                padding: 2.5rem;
+                background: rgba(15, 23, 42, 0.92);
+                border-radius: 18px;
+                box-shadow: 0 35px 60px rgba(2, 6, 23, 0.65);
+                border: 1px solid rgba(148, 163, 184, 0.2);
+            }
+
+            h1 {
+                margin-top: 0;
+                font-size: 1.9rem;
+                text-align: center;
+                letter-spacing: 0.1em;
+            }
+
+            ul {
+                list-style: none;
+                padding: 0;
+            }
+
+            li {
+                background: rgba(220, 38, 38, 0.16);
+                border: 1px solid rgba(248, 113, 113, 0.45);
+                padding: 0.85rem 1rem;
+                border-radius: 12px;
+                margin-bottom: 0.75rem;
+            }
+
+            .actions {
+                text-align: center;
+                margin-top: 2rem;
+            }
+
+            a.button {
+                display: inline-block;
+                padding: 0.75rem 2.5rem;
+                border-radius: 999px;
+                text-decoration: none;
+                background: linear-gradient(135deg, #2563eb, #06b6d4);
+                color: #0f172a;
+                letter-spacing: 0.1em;
+                font-weight: 600;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="error-panel">
+            <h1>Access Denied</h1>
+            <p>The login request could not be completed:</p>
+            <ul>
+                <?php foreach ($errors as $error) : ?>
+                    <li><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                <?php endforeach; ?>
+            </ul>
+            <div class="actions">
+                <a class="button" href="/form_login.php">Return to Login</a>
+            </div>
+        </div>
+    </body>
+    </html>
+    <?php
+}

--- a/verify_email.php
+++ b/verify_email.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
+
+ensureSessionStarted();
+$config = require __DIR__ . '/includes/config.php';
+
+$token = trim((string) ($_GET['token'] ?? ''));
+$statusMessage = '';
+$isSuccess = false;
+
+if ($token === '') {
+    $statusMessage = 'The verification link is invalid or missing.';
+} else {
+    $stmt = $mysqli->prepare('SELECT user_id, username, email_verified_at FROM user_account WHERE email_verification_token = ? LIMIT 1');
+    $stmt->bind_param('s', $token);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $user = $result->fetch_assoc();
+
+    if (!$user) {
+        $statusMessage = 'Verification token not found or already used.';
+    } elseif (!empty($user['email_verified_at'])) {
+        $statusMessage = 'Your email has already been verified. You can log in now.';
+        $isSuccess = true;
+    } else {
+        markEmailVerified($mysqli, (int) $user['user_id']);
+        logSecurityEvent($mysqli, 'email_verified', currentIpAddress());
+        $statusMessage = 'Success! Your email has been confirmed. You can now access your account.';
+        $isSuccess = true;
+    }
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Email Verification | <?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?></title>
+    <link rel="stylesheet" href="stylesheet.css">
+    <style>
+        body {
+            background: radial-gradient(circle at top, #0b1120, #020617 70%);
+            color: #f8fafc;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            padding: 2rem;
+        }
+
+        .verification-card {
+            max-width: 520px;
+            width: 100%;
+            padding: 2.5rem;
+            background: rgba(15, 23, 42, 0.92);
+            border-radius: 18px;
+            box-shadow: 0 30px 55px rgba(2, 6, 23, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            text-align: center;
+        }
+
+        h1 {
+            margin-top: 0;
+            font-size: 2rem;
+            letter-spacing: 0.1em;
+        }
+
+        .status-message {
+            margin-top: 1.5rem;
+            padding: 1.25rem 1.5rem;
+            border-radius: 12px;
+            font-size: 1.05rem;
+            line-height: 1.6;
+            background: <?php echo $isSuccess ? 'rgba(22, 163, 74, 0.18)' : 'rgba(220, 38, 38, 0.18)'; ?>;
+            border: 1px solid <?php echo $isSuccess ? 'rgba(74, 222, 128, 0.45)' : 'rgba(248, 113, 113, 0.45)'; ?>;
+            color: <?php echo $isSuccess ? '#bbf7d0' : '#fecaca'; ?>;
+        }
+
+        a.button {
+            display: inline-block;
+            margin-top: 2rem;
+            padding: 0.85rem 2.5rem;
+            border-radius: 999px;
+            text-decoration: none;
+            background: linear-gradient(135deg, #22d3ee, #3b82f6);
+            color: #0f172a;
+            letter-spacing: 0.1em;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="verification-card">
+        <h1>Email Verification</h1>
+        <div class="status-message">
+            <?php echo htmlspecialchars($statusMessage, ENT_QUOTES, 'UTF-8'); ?>
+        </div>
+        <a class="button" href="/form_login.php">Proceed to Login</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- capture network ownership and user agent details whenever security events are logged
- refuse registration, login, and API authentication from banned IP addresses with operator-supplied reasons
- extend the database schema with metadata columns and a dedicated banned_networks table for managing network bans

## Testing
- php -l includes/security.php
- php -l newuserpost.php
- php -l post_login.php
- php -l auth.php

------
https://chatgpt.com/codex/tasks/task_e_68d522685390832c9a15a5dd13bb2940