### PR TITLE
Add SWG+ dashboard and player profile management

### DIFF
--- a/changepassword.php
+++ b/changepassword.php
@@ -6,12 +6,7 @@ require_once __DIR__ . '/includes/db_connect.php';
 require_once __DIR__ . '/includes/auth_functions.php';
 
 ensureSessionStarted();
-
-if (!isset($_SESSION['user'])) {
-    $_SESSION['urlredirect'] = basename($_SERVER['PHP_SELF']);
-    header('Location: form_login.php');
-    exit;
-}
+requireAuthenticatedUser('/changepassword.php');
 
 $csrfToken = getCsrfToken();
 $config = require __DIR__ . '/includes/config.php';

--- a/create_database_table.sql
+++ b/create_database_table.sql
@@ -14,10 +14,18 @@ CREATE TABLE `user_account` (
   `user_id` int(11) NOT NULL,
   `accesslevel` varchar(255) NOT NULL DEFAULT 'standard',
   `username` varchar(255) NOT NULL,
+  `display_name` varchar(255) DEFAULT NULL,
   `email` varchar(255) NOT NULL,
   `password_hash` varchar(255) NOT NULL,
   `email_verification_token` varchar(255) DEFAULT NULL,
   `email_verified_at` datetime DEFAULT NULL,
+  `faction` varchar(100) DEFAULT NULL,
+  `favorite_activity` varchar(100) DEFAULT NULL,
+  `timezone` varchar(64) DEFAULT NULL,
+  `discord_handle` varchar(100) DEFAULT NULL,
+  `avatar_url` varchar(255) DEFAULT NULL,
+  `biography` text,
+  `last_login_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,411 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
+require_once __DIR__ . '/includes/server_status.php';
+
+ensureSessionStarted();
+requireAuthenticatedUser('/dashboard.php');
+
+$userId = currentUserId();
+$user = $userId !== null ? findUserById($mysqli, $userId) : null;
+
+if (!$user) {
+    $_SESSION = [];
+    header('Location: /logout.php');
+    exit;
+}
+
+$config = require __DIR__ . '/includes/config.php';
+
+$serverHost = getenv('SWG_SERVER_HOST') ?: '127.0.0.1';
+$loginPort = (int) (getenv('SWG_LOGIN_PORT') ?: 44453);
+$gamePort = (int) (getenv('SWG_GAME_PORT') ?: 44463);
+$mysqlPort = (int) (getenv('SWG_MYSQL_PORT') ?: 3306);
+$timeoutSeconds = (int) (getenv('SWG_PORT_TIMEOUT') ?: 5);
+
+$statuses = resolveServerStatuses($serverHost, $timeoutSeconds, [
+    'Login Server' => $loginPort,
+    'Game Server' => $gamePort,
+    'Database' => $mysqlPort,
+]);
+
+$onlinePlayers = null;
+$totalCharacters = null;
+
+try {
+    $stmt = $mysqli->query('SELECT COUNT(*) AS online_count FROM characters WHERE online = 1');
+    $row = $stmt->fetch_assoc();
+    $onlinePlayers = isset($row['online_count']) ? (int) $row['online_count'] : null;
+} catch (Throwable $exception) {
+    $onlinePlayers = null;
+}
+
+try {
+    $totalResult = $mysqli->query('SELECT COUNT(*) AS total_count FROM characters');
+    $totalRow = $totalResult->fetch_assoc();
+    $totalCharacters = isset($totalRow['total_count']) ? (int) $totalRow['total_count'] : null;
+} catch (Throwable $exception) {
+    $totalCharacters = null;
+}
+
+$displayName = currentDisplayName();
+$createdAt = $user['created_at'] ?? null;
+$emailVerifiedAt = $user['email_verified_at'] ?? null;
+$lastLoginAt = $user['last_login_at'] ?? null;
+$faction = $user['faction'] ?: 'Independent';
+$favoriteActivity = $user['favorite_activity'] ?: 'Explorer';
+$discordHandle = $user['discord_handle'] ?: 'Not provided';
+$timezone = $user['timezone'] ?: 'UTC';
+$biography = trim((string) ($user['biography'] ?? ''));
+$avatarUrl = $user['avatar_url'] ?: '/images/swgsource.png';
+
+$localTime = null;
+try {
+    $utcNow = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+    $localTime = $utcNow->setTimezone(new DateTimeZone($timezone))->format('M j, Y \a\t g:i A');
+} catch (Throwable $exception) {
+    $localTime = null;
+}
+
+$profileFieldsTotal = 5;
+$profileFieldsCompleted = 0;
+if (trim((string) ($user['display_name'] ?? '')) !== '') {
+    $profileFieldsCompleted++;
+}
+if (($user['faction'] ?? '') !== null && trim((string) $user['faction']) !== '') {
+    $profileFieldsCompleted++;
+}
+if (($user['favorite_activity'] ?? '') !== null && trim((string) $user['favorite_activity']) !== '') {
+    $profileFieldsCompleted++;
+}
+if (($user['discord_handle'] ?? '') !== null && trim((string) $user['discord_handle']) !== '') {
+    $profileFieldsCompleted++;
+}
+if ($biography !== '') {
+    $profileFieldsCompleted++;
+}
+$profileCompletion = (int) round(($profileFieldsCompleted / $profileFieldsTotal) * 100);
+$profileCompletion = max(10, min(100, $profileCompletion));
+
+$missions = [
+    'Escort a convoy from Anchorhead to Mos Eisley.',
+    'Assist a guild mate with a heroic instance run.',
+    'Harvest rare resources on the forest moon of Endor.',
+    'Host a cantina night for entertainers and crafters.',
+];
+shuffle($missions);
+$highlightedMissions = array_slice($missions, 0, 3);
+
+$activityLog = [];
+if ($lastLoginAt) {
+    $activityLog[] = 'Last login recorded on ' . (new DateTimeImmutable($lastLoginAt . ' UTC'))->format('M j, Y \a\t g:i A \U\T\C');
+}
+if ($emailVerifiedAt) {
+    $activityLog[] = 'Email verified on ' . (new DateTimeImmutable($emailVerifiedAt . ' UTC'))->format('M j, Y');
+}
+$activityLog[] = 'Access level: ' . ucfirst(strtolower((string) ($user['accesslevel'] ?? 'standard')));
+
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?> | Command Dashboard</title>
+    <link rel="stylesheet" href="/stylesheet.css">
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: radial-gradient(circle at top, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.95) 45%, rgba(0, 0, 0, 0.98) 100%), url('/images/stormtrooper.jpg') no-repeat center/cover fixed;
+            color: #e2e8f0;
+        }
+
+        .dashboard-shell {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 3rem 1.5rem 4rem;
+        }
+
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+            align-items: center;
+            text-align: center;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 2.5rem;
+            letter-spacing: 0.12em;
+        }
+
+        header p {
+            margin: 0;
+            color: #cbd5e1;
+        }
+
+        .layout-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 1.75rem;
+            margin-top: 2.5rem;
+        }
+
+        .card {
+            background: rgba(15, 23, 42, 0.9);
+            border-radius: 18px;
+            padding: 1.75rem;
+            border: 1px solid rgba(148, 163, 184, 0.22);
+            box-shadow: 0 28px 48px rgba(2, 6, 23, 0.55);
+        }
+
+        .profile-card {
+            display: grid;
+            grid-template-columns: 120px 1fr;
+            gap: 1.25rem;
+            align-items: center;
+        }
+
+        .profile-card img {
+            width: 120px;
+            height: 120px;
+            border-radius: 50%;
+            object-fit: cover;
+            border: 3px solid rgba(56, 189, 248, 0.4);
+            box-shadow: 0 12px 22px rgba(15, 23, 42, 0.5);
+        }
+
+        .profile-card h2 {
+            margin: 0;
+            letter-spacing: 0.08em;
+        }
+
+        .profile-meta {
+            margin: 0.5rem 0 0;
+            color: #94a3b8;
+            line-height: 1.6;
+        }
+
+        .status-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            background: rgba(74, 222, 128, 0.15);
+            color: #bbf7d0;
+        }
+
+        .progress-track {
+            height: 10px;
+            border-radius: 999px;
+            background: rgba(148, 163, 184, 0.25);
+            overflow: hidden;
+            margin: 1rem 0;
+        }
+
+        .progress-fill {
+            height: 100%;
+            background: linear-gradient(135deg, #38bdf8, #34d399);
+        }
+
+        .server-status-list {
+            list-style: none;
+            padding: 0;
+            margin: 1.25rem 0 0;
+        }
+
+        .server-status-list li {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem 0;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        .server-status-list li:last-child {
+            border-bottom: none;
+        }
+
+        .status-online {
+            color: #4ade80;
+            font-weight: 600;
+        }
+
+        .status-offline {
+            color: #f87171;
+            font-weight: 600;
+        }
+
+        .quick-links {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 0.75rem;
+            margin-top: 1.25rem;
+        }
+
+        .quick-links a {
+            display: inline-block;
+            padding: 0.85rem 1.15rem;
+            border-radius: 12px;
+            text-decoration: none;
+            text-align: center;
+            background: rgba(37, 99, 235, 0.18);
+            color: #bfdbfe;
+            font-weight: 600;
+            letter-spacing: 0.05em;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .quick-links a:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 18px 28px rgba(37, 99, 235, 0.35);
+        }
+
+        .card h3 {
+            margin-top: 0;
+            letter-spacing: 0.1em;
+        }
+
+        .card ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .card ul li {
+            padding: 0.65rem 0;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        .card ul li:last-child {
+            border-bottom: none;
+        }
+
+        .biography {
+            margin-top: 1rem;
+            line-height: 1.6;
+            color: #cbd5e1;
+        }
+
+        footer {
+            margin-top: 3rem;
+            text-align: center;
+            color: #94a3b8;
+            font-size: 0.9rem;
+        }
+
+        @media (max-width: 640px) {
+            .profile-card {
+                grid-template-columns: 1fr;
+                text-align: center;
+            }
+
+            .profile-card img {
+                margin: 0 auto;
+            }
+
+            .quick-links {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="dashboard-shell">
+        <header>
+            <h1>Welcome back, <?php echo htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8'); ?></h1>
+            <p>Your personal SWG+ operations center is standing by.</p>
+        </header>
+
+        <div class="layout-grid">
+            <section class="card profile-card" aria-label="Commander profile">
+                <img src="<?php echo htmlspecialchars($avatarUrl, ENT_QUOTES, 'UTF-8'); ?>" alt="Avatar">
+                <div>
+                    <h2><?php echo htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8'); ?></h2>
+                    <div class="profile-meta">
+                        <div><strong>Faction:</strong> <?php echo htmlspecialchars($faction, ENT_QUOTES, 'UTF-8'); ?></div>
+                        <div><strong>Role:</strong> <?php echo htmlspecialchars($favoriteActivity, ENT_QUOTES, 'UTF-8'); ?></div>
+                        <div><strong>Discord:</strong> <?php echo htmlspecialchars($discordHandle, ENT_QUOTES, 'UTF-8'); ?></div>
+                        <?php if ($localTime) : ?>
+                            <div><strong>Local Time:</strong> <?php echo htmlspecialchars($localTime, ENT_QUOTES, 'UTF-8'); ?></div>
+                        <?php endif; ?>
+                    </div>
+                    <div class="status-pill">Profile <?php echo $profileCompletion; ?>% complete</div>
+                    <div class="progress-track" role="progressbar" aria-valuenow="<?php echo $profileCompletion; ?>" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress-fill" style="width: <?php echo $profileCompletion; ?>%"></div>
+                    </div>
+                    <?php if ($biography !== '') : ?>
+                        <p class="biography">“<?php echo nl2br(htmlspecialchars($biography, ENT_QUOTES, 'UTF-8')); ?>”</p>
+                    <?php else : ?>
+                        <p class="biography">Add a biography to tell fellow pilots about your adventures.</p>
+                    <?php endif; ?>
+                    <div class="quick-links">
+                        <a href="/profile.php">Edit Profile</a>
+                        <a href="/changepassword.php">Change Password</a>
+                        <a href="/forums/index.php">Visit Forums</a>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card" aria-label="Server status">
+                <h3>Server Diagnostics</h3>
+                <ul class="server-status-list">
+                    <?php foreach ($statuses as $label => $online) : ?>
+                        <li>
+                            <span><?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></span>
+                            <span class="<?php echo $online ? 'status-online' : 'status-offline'; ?>"><?php echo $online ? 'Online' : 'Offline'; ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                    <li>
+                        <span>Pilots in Galaxy</span>
+                        <span class="<?php echo $onlinePlayers !== null ? 'status-online' : 'status-offline'; ?>">
+                            <?php echo $onlinePlayers !== null ? $onlinePlayers : 'Unavailable'; ?>
+                        </span>
+                    </li>
+                    <?php if ($totalCharacters !== null) : ?>
+                        <li>
+                            <span>Total Registered Characters</span>
+                            <span><?php echo $totalCharacters; ?></span>
+                        </li>
+                    <?php endif; ?>
+                </ul>
+            </section>
+
+            <section class="card" aria-label="Mission queue">
+                <h3>Mission Briefings</h3>
+                <ul>
+                    <?php foreach ($highlightedMissions as $mission) : ?>
+                        <li><?php echo htmlspecialchars($mission, ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+                <p style="margin-top: 1rem; color: #94a3b8;">Need inspiration? Roll a new objective every time you visit.</p>
+            </section>
+
+            <section class="card" aria-label="Account history">
+                <h3>Account Timeline</h3>
+                <ul>
+                    <?php if ($createdAt) : ?>
+                        <li>Account created on <?php echo htmlspecialchars((new DateTimeImmutable($createdAt . ' UTC'))->format('M j, Y'), ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endif; ?>
+                    <?php foreach ($activityLog as $entry) : ?>
+                        <li><?php echo htmlspecialchars($entry, ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+        </div>
+
+        <footer>
+            &copy; <?php echo date('Y'); ?> <?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?>. Harness the power of the SWG+ network.
+        </footer>
+    </div>
+</body>
+</html>

--- a/includes/auth_functions.php
+++ b/includes/auth_functions.php
@@ -12,6 +12,17 @@ function findUserByUsername(mysqli $db, string $username): ?array
     return $user ?: null;
 }
 
+function findUserById(mysqli $db, int $userId): ?array
+{
+    $stmt = $db->prepare('SELECT * FROM user_account WHERE user_id = ? LIMIT 1');
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    $user = $result->fetch_assoc();
+    return $user ?: null;
+}
+
 function findUserByEmail(mysqli $db, string $email): ?array
 {
     $stmt = $db->prepare('SELECT * FROM user_account WHERE email = ? LIMIT 1');
@@ -39,5 +50,30 @@ function markEmailVerified(mysqli $db, int $userId): void
     $null = null;
     $stmt = $db->prepare('UPDATE user_account SET email_verified_at = ?, email_verification_token = ? WHERE user_id = ?');
     $stmt->bind_param('ssi', $timestamp, $null, $userId);
+    $stmt->execute();
+}
+
+function updateLastLogin(mysqli $db, int $userId): void
+{
+    $timestamp = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+    $stmt = $db->prepare('UPDATE user_account SET last_login_at = ? WHERE user_id = ?');
+    $stmt->bind_param('si', $timestamp, $userId);
+    $stmt->execute();
+}
+
+function updateUserProfile(mysqli $db, int $userId, array $profile): void
+{
+    $stmt = $db->prepare('UPDATE user_account SET display_name = ?, timezone = ?, faction = ?, favorite_activity = ?, discord_handle = ?, avatar_url = ?, biography = ?, updated_at = CURRENT_TIMESTAMP WHERE user_id = ?');
+    $stmt->bind_param(
+        'sssssssi',
+        $profile['display_name'],
+        $profile['timezone'],
+        $profile['faction'],
+        $profile['favorite_activity'],
+        $profile['discord_handle'],
+        $profile['avatar_url'],
+        $profile['biography'],
+        $userId
+    );
     $stmt->execute();
 }

--- a/includes/server_status.php
+++ b/includes/server_status.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+function checkServiceStatus(string $host, int $port, int $timeoutSeconds): bool
+{
+    $connection = @fsockopen($host, $port, $errno, $errstr, $timeoutSeconds);
+    if (is_resource($connection)) {
+        fclose($connection);
+        return true;
+    }
+
+    return false;
+}
+
+function resolveServerStatuses(string $host, int $timeoutSeconds, array $ports): array
+{
+    $statuses = [];
+    foreach ($ports as $key => $port) {
+        $statuses[$key] = checkServiceStatus($host, (int) $port, $timeoutSeconds);
+    }
+
+    return $statuses;
+}

--- a/newuserpost.php
+++ b/newuserpost.php
@@ -104,9 +104,12 @@ if (!empty($errors)) {
 $passwordHash = password_hash($password, PASSWORD_DEFAULT);
 $verificationToken = bin2hex(random_bytes(32));
 $accessLevel = 'standard';
+$displayName = $username;
+$defaultFaction = 'Independent';
+$defaultActivity = 'Explorer';
 
-$stmt = $mysqli->prepare('INSERT INTO user_account (accesslevel, username, email, password_hash, email_verification_token) VALUES (?, ?, ?, ?, ?)');
-$stmt->bind_param('sssss', $accessLevel, $username, $email, $passwordHash, $verificationToken);
+$stmt = $mysqli->prepare('INSERT INTO user_account (accesslevel, username, display_name, email, password_hash, email_verification_token, faction, favorite_activity) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+$stmt->bind_param('ssssssss', $accessLevel, $username, $displayName, $email, $passwordHash, $verificationToken, $defaultFaction, $defaultActivity);
 $stmt->execute();
 
 logSecurityEvent($mysqli, 'register', $ipAddress);

--- a/post_changepassword.php
+++ b/post_changepassword.php
@@ -6,12 +6,8 @@ require_once __DIR__ . '/includes/db_connect.php';
 require_once __DIR__ . '/includes/auth_functions.php';
 
 ensureSessionStarted();
+requireAuthenticatedUser('/changepassword.php');
 $config = require __DIR__ . '/includes/config.php';
-
-if (!isset($_SESSION['user'])) {
-    header('Location: form_login.php');
-    exit;
-}
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Location: changepassword.php');

--- a/post_login.php
+++ b/post_login.php
@@ -70,10 +70,8 @@ if (strcasecmp($user['accesslevel'], 'banned') === 0) {
 logSecurityEvent($mysqli, 'login', $ipAddress);
 session_regenerate_id(true);
 
-$_SESSION['user_id'] = (int) $user['user_id'];
-$_SESSION['user'] = $user['username'];
-$_SESSION['username'] = $user['username'];
-$_SESSION['accesslevel'] = $user['accesslevel'];
+refreshAuthenticatedSession($user);
+updateLastLogin($mysqli, (int) $user['user_id']);
 
 if (isset($_SESSION['urlredirect']) && $_SESSION['urlredirect'] !== '') {
     $redirectName = $_SESSION['urlredirect'];
@@ -82,7 +80,7 @@ if (isset($_SESSION['urlredirect']) && $_SESSION['urlredirect'] !== '') {
     exit;
 }
 
-header('Location: index.php');
+header('Location: dashboard.php');
 exit;
 
 function renderLoginResponse(array $errors): void

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,339 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/db_connect.php';
+require_once __DIR__ . '/includes/auth_functions.php';
+
+ensureSessionStarted();
+requireAuthenticatedUser('/profile.php');
+
+$config = require __DIR__ . '/includes/config.php';
+$userId = currentUserId();
+$user = $userId !== null ? findUserById($mysqli, $userId) : null;
+
+if (!$user) {
+    $_SESSION = [];
+    header('Location: /logout.php');
+    exit;
+}
+
+$factions = [
+    'Galactic Empire',
+    'Rebel Alliance',
+    'Independent',
+    'Smuggler Coalition',
+    'Mandalorian Clans',
+    'Galactic Civilian Corps',
+];
+
+$activities = [
+    'Pilot',
+    'Crafter',
+    'Bounty Hunter',
+    'Entertainer',
+    'Guild Quartermaster',
+    'Explorer',
+];
+
+$timezones = [
+    'UTC',
+    'America/New_York',
+    'America/Chicago',
+    'America/Denver',
+    'America/Los_Angeles',
+    'Europe/London',
+    'Europe/Paris',
+    'Europe/Berlin',
+    'Europe/Moscow',
+    'Asia/Tokyo',
+    'Asia/Singapore',
+    'Australia/Sydney',
+];
+
+$errors = [];
+$success = false;
+
+$displayName = trim((string) ($user['display_name'] ?? $user['username'] ?? ''));
+$selectedFaction = $user['faction'] ?: 'Independent';
+$selectedActivity = $user['favorite_activity'] ?: 'Explorer';
+$selectedTimezone = $user['timezone'] ?: 'UTC';
+$discordHandle = trim((string) ($user['discord_handle'] ?? ''));
+$avatarUrl = trim((string) ($user['avatar_url'] ?? ''));
+$biography = trim((string) ($user['biography'] ?? ''));
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken($_POST['csrf_token'] ?? null)) {
+        $errors[] = 'Session expired. Please resubmit the form.';
+    } else {
+        $displayName = trim((string) ($_POST['display_name'] ?? ''));
+        $selectedFaction = (string) ($_POST['faction'] ?? 'Independent');
+        $selectedActivity = (string) ($_POST['favorite_activity'] ?? 'Explorer');
+        $selectedTimezone = (string) ($_POST['timezone'] ?? 'UTC');
+        $discordHandle = trim((string) ($_POST['discord_handle'] ?? ''));
+        $avatarUrl = trim((string) ($_POST['avatar_url'] ?? ''));
+        $biography = trim((string) ($_POST['biography'] ?? ''));
+
+        if ($displayName === '' || strlen($displayName) < 3 || strlen($displayName) > 60) {
+            $errors[] = 'Display name must be between 3 and 60 characters.';
+        }
+
+        if (!in_array($selectedFaction, $factions, true)) {
+            $errors[] = 'Please choose a valid faction alignment.';
+        }
+
+        if (!in_array($selectedActivity, $activities, true)) {
+            $errors[] = 'Select a playstyle that best represents you.';
+        }
+
+        if (!in_array($selectedTimezone, $timezones, true)) {
+            $errors[] = 'Please choose a supported timezone.';
+        }
+
+        if ($discordHandle !== '' && !preg_match('/^@?[A-Za-z0-9_.\-]{2,32}(#\d{4})?$/', $discordHandle)) {
+            $errors[] = 'Discord handle should include 2-32 characters and may end with #1234.';
+        }
+
+        if ($avatarUrl !== '') {
+            if (!filter_var($avatarUrl, FILTER_VALIDATE_URL) || !preg_match('/^https?:\/\//i', $avatarUrl)) {
+                $errors[] = 'Avatar URL must be a valid http or https address.';
+            }
+        }
+
+        if ($biography !== '') {
+            $biography = strip_tags($biography);
+            if (strlen($biography) > 700) {
+                $errors[] = 'Biography cannot exceed 700 characters.';
+            }
+        }
+
+        if (empty($errors)) {
+            $profileData = [
+                'display_name' => $displayName,
+                'timezone' => $selectedTimezone,
+                'faction' => $selectedFaction,
+                'favorite_activity' => $selectedActivity,
+                'discord_handle' => $discordHandle,
+                'avatar_url' => $avatarUrl,
+                'biography' => $biography,
+            ];
+
+            updateUserProfile($mysqli, (int) $userId, $profileData);
+            $user = findUserById($mysqli, (int) $userId) ?? $user;
+            refreshAuthenticatedSession($user);
+            $success = true;
+        }
+    }
+}
+
+$csrfToken = getCsrfToken();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?php echo htmlspecialchars($config['site_name'], ENT_QUOTES, 'UTF-8'); ?> | Pilot Profile</title>
+    <link rel="stylesheet" href="/stylesheet.css">
+    <style>
+        body {
+            background: linear-gradient(140deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.96)), url('/images/vaderdeathstar.jpg') no-repeat center/cover fixed;
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            color: #e2e8f0;
+        }
+
+        .profile-wrapper {
+            max-width: 820px;
+            margin: 4rem auto;
+            padding: 3rem;
+            background: rgba(15, 23, 42, 0.9);
+            border-radius: 20px;
+            box-shadow: 0 30px 55px rgba(2, 6, 23, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+        }
+
+        h1 {
+            margin-top: 0;
+            text-align: center;
+            font-size: 2.2rem;
+            letter-spacing: 0.12em;
+        }
+
+        p.subtitle {
+            text-align: center;
+            color: #cbd5e1;
+            margin-bottom: 2rem;
+        }
+
+        .form-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        label {
+            display: block;
+            font-size: 0.8rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            margin-bottom: 0.35rem;
+            color: #94a3b8;
+        }
+
+        input[type="text"],
+        input[type="url"],
+        select,
+        textarea {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border-radius: 10px;
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            background: rgba(15, 23, 42, 0.85);
+            color: #e2e8f0;
+            font-size: 1rem;
+        }
+
+        textarea {
+            min-height: 140px;
+            resize: vertical;
+        }
+
+        .actions {
+            margin-top: 2.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            justify-content: center;
+        }
+
+        button[type="submit"] {
+            padding: 0.95rem 2.75rem;
+            border-radius: 999px;
+            border: none;
+            font-size: 1.05rem;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            background: linear-gradient(135deg, #38bdf8, #34d399);
+            color: #0f172a;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        button[type="submit"]:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 18px 32px rgba(52, 211, 153, 0.35);
+        }
+
+        .notice {
+            padding: 0.9rem 1.1rem;
+            border-radius: 12px;
+            margin-bottom: 1.75rem;
+        }
+
+        .notice.error {
+            background: rgba(220, 38, 38, 0.15);
+            border: 1px solid rgba(248, 113, 113, 0.45);
+            color: #fecaca;
+        }
+
+        .notice.success {
+            background: rgba(13, 148, 136, 0.18);
+            border: 1px solid rgba(45, 212, 191, 0.45);
+            color: #ccfbf1;
+        }
+
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: #bae6fd;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .back-link:hover {
+            color: #facc15;
+        }
+
+        @media (max-width: 640px) {
+            .profile-wrapper {
+                padding: 2rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="profile-wrapper">
+        <a class="back-link" href="/dashboard.php">&larr; Back to Dashboard</a>
+        <h1>Customize Your Pilot Profile</h1>
+        <p class="subtitle">Fine-tune your public dossier so allies know who to call on for the next mission.</p>
+
+        <?php if ($success) : ?>
+            <div class="notice success">Profile updated! Your legend grows across the galaxy.</div>
+        <?php endif; ?>
+
+        <?php if (!empty($errors)) : ?>
+            <div class="notice error">
+                <strong>We detected a few issues:</strong>
+                <ul>
+                    <?php foreach ($errors as $error) : ?>
+                        <li><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        <?php endif; ?>
+
+        <form method="post" action="profile.php" novalidate>
+            <div class="form-grid">
+                <div>
+                    <label for="display_name">Display Name</label>
+                    <input type="text" id="display_name" name="display_name" required maxlength="60" value="<?php echo htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+                <div>
+                    <label for="faction">Preferred Faction</label>
+                    <select id="faction" name="faction" required>
+                        <?php foreach ($factions as $faction) : ?>
+                            <option value="<?php echo htmlspecialchars($faction, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $faction === $selectedFaction ? 'selected' : ''; ?>><?php echo htmlspecialchars($faction, ENT_QUOTES, 'UTF-8'); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div>
+                    <label for="favorite_activity">Playstyle</label>
+                    <select id="favorite_activity" name="favorite_activity" required>
+                        <?php foreach ($activities as $activity) : ?>
+                            <option value="<?php echo htmlspecialchars($activity, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $activity === $selectedActivity ? 'selected' : ''; ?>><?php echo htmlspecialchars($activity, ENT_QUOTES, 'UTF-8'); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div>
+                    <label for="timezone">Primary Timezone</label>
+                    <select id="timezone" name="timezone" required>
+                        <?php foreach ($timezones as $timezone) : ?>
+                            <option value="<?php echo htmlspecialchars($timezone, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $timezone === $selectedTimezone ? 'selected' : ''; ?>><?php echo htmlspecialchars($timezone, ENT_QUOTES, 'UTF-8'); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div>
+                    <label for="discord_handle">Discord Handle</label>
+                    <input type="text" id="discord_handle" name="discord_handle" maxlength="40" placeholder="@SWGPlusPilot" value="<?php echo htmlspecialchars($discordHandle, ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+                <div>
+                    <label for="avatar_url">Avatar URL</label>
+                    <input type="url" id="avatar_url" name="avatar_url" placeholder="https://example.com/avatar.jpg" value="<?php echo htmlspecialchars($avatarUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+            </div>
+            <div style="margin-top: 1.5rem;">
+                <label for="biography">Biography</label>
+                <textarea id="biography" name="biography" maxlength="700" placeholder="Share your greatest victories and signature moves."><?php echo htmlspecialchars($biography, ENT_QUOTES, 'UTF-8'); ?></textarea>
+            </div>
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+            <div class="actions">
+                <button type="submit">Save Profile</button>
+                <a class="back-link" href="/logout.php">Log Out</a>
+            </div>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable session helpers and server status utilities to support authenticated experiences
- create a cinematic SWG+ dashboard that surfaces account details, live server intel, and mission inspiration
- deliver a full pilot profile editor and extend the user schema/registration flow to capture new social fields

## Testing
- php -l index.php
- php -l dashboard.php
- php -l profile.php
- php -l includes/security.php
- php -l includes/auth_functions.php
- php -l newuserpost.php
- php -l post_login.php
- php -l post_changepassword.php
- php -l changepassword.php
- php -l includes/server_status.php


------
https://chatgpt.com/codex/tasks/task_e_68d5441c402c832cacc3c2c8778cd655